### PR TITLE
chore(npm): prepare for npm publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,22 @@
 {
   "name": "@divvi/referral-sdk",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "SDK for managing referrals in the Divvi ecosystem",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "yarn build",
+    "clean": "rm -rf dist",
+    "build": "yarn clean && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,3 +117,6 @@ export async function submitReferral({
 
   return response
 }
+
+// Re-export only the types that are needed for the public API
+export { Address, InvalidAddressError } from './types'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
-  "exclude": ["node_modules", "test", "**/*.test.ts"]
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/index.ts", "src/types.ts", "src/constants.ts"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "test", "node_modules"]
 }


### PR DESCRIPTION
```bash
$ npm pack --dry-run

> @divvi/referral-sdk@0.0.1 prepare
> yarn build

yarn run v1.22.17
warning ../../../package.json: No license field
$ yarn clean && tsc -p tsconfig.build.json
warning ../../../package.json: No license field
$ rm -rf dist
✨  Done in 1.10s.
npm notice
npm notice 📦  @divvi/referral-sdk@0.0.1
npm notice Tarball Contents
npm notice 11.4kB LICENSE
npm notice 3.6kB README.md
npm notice 322B dist/constants.d.ts
npm notice 258B dist/constants.d.ts.map
npm notice 448B dist/constants.js
npm notice 222B dist/constants.js.map
npm notice 1.4kB dist/index.d.ts
npm notice 553B dist/index.d.ts.map
npm notice 4.3kB dist/index.js
npm notice 2.5kB dist/index.js.map
npm notice 321B dist/types.d.ts
npm notice 298B dist/types.d.ts.map
npm notice 378B dist/types.js
npm notice 266B dist/types.js.map
npm notice 1.5kB package.json
npm notice Tarball Details
npm notice name: @divvi/referral-sdk
npm notice version: 0.0.1
npm notice filename: divvi-referral-sdk-0.0.1.tgz
npm notice package size: 9.2 kB
npm notice unpacked size: 27.7 kB
npm notice shasum: 93c701d55f1670320c85e5a6bfeb96c9dd64e8c2
npm notice integrity: sha512-E/khDHJ77FKmT[...]4zyIHjEgnEjmg==
npm notice total files: 15
npm notice
divvi-referral-sdk-0.0.1.tgz
```