### PR TITLE
feat!: replace getDataSuffix with getReferralTag and require user parameter

### DIFF
--- a/scripts/test-referral.ts
+++ b/scripts/test-referral.ts
@@ -1,5 +1,5 @@
-import { getDataSuffix, submitReferral } from '../src/index'
 import { Address, createWalletClient, Hex, http, parseUnits } from 'viem'
+import { getReferralTag, submitReferral } from '../src/index'
 import { celo } from 'viem/chains'
 import { privateKeyToAccount } from 'viem/accounts'
 
@@ -64,7 +64,8 @@ async function main() {
       ],
       functionName: 'transfer',
       args: [consumerAddress, parseUnits('0.001', 18)], // 0.001 cUSD
-      dataSuffix: `0x${getDataSuffix({
+      dataSuffix: `0x${getReferralTag({
+        user: account.address,
         consumer: consumerAddress,
         providers: providerAddresses,
       })}`,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,8 @@
-import { FormatID } from './types'
-
 // Magic prefix is keccak256("divvi").slice(2, 10)
 export const DIVVI_MAGIC_PREFIX = '6decb85d'
 
 /**
- * Maps format IDs to their byte representations.
- * Each format ID is represented as a 2-character hex string (1 byte).
+ * Format byte for referral tag encoding (v2).
+ * Represented as a 2-character hex string (1 byte).
  */
-export const FORMAT_ID_BYTES: Record<FormatID, string> = {
-  default: '00',
-}
+export const REFERRAL_TAG_V2_FORMAT_BYTE = '01'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@
 export const DIVVI_MAGIC_PREFIX = '6decb85d'
 
 /**
- * Format byte for referral tag encoding (v2).
+ * Format byte for referral tag encoding (format 1).
  * Represented as a 2-character hex string (1 byte).
  */
-export const REFERRAL_TAG_V2_FORMAT_BYTE = '01'
+export const REFERRAL_TAG_FORMAT_1_BYTE = '01'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,7 @@ import { decodeAbiParameters, hexToNumber } from 'viem'
 import { getReferralTag as getReferralTagOriginal, submitReferral } from '.'
 import { getReferralTag as getReferralTagViem } from '../test/viemReferenceVersion'
 import { InvalidAddressError, Address } from './types'
-import { DIVVI_MAGIC_PREFIX, REFERRAL_TAG_V2_FORMAT_BYTE } from './constants'
+import { DIVVI_MAGIC_PREFIX, REFERRAL_TAG_FORMAT_1_BYTE } from './constants'
 
 const TEST_USER = '0x9999999999999999999999999999999999999999'
 const TEST_CONSUMER = '0x1234567890123456789012345678901234567890'
@@ -110,7 +110,7 @@ describe.each([
 
       // The format byte should be next
       const formatByte = result.slice(8, 10)
-      expect(formatByte).toBe(REFERRAL_TAG_V2_FORMAT_BYTE)
+      expect(formatByte).toBe(REFERRAL_TAG_FORMAT_1_BYTE)
 
       // The next 4 characters should be the length of the payload
       const payloadLength = result.slice(10, 14)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,191 +1,163 @@
 import { decodeAbiParameters, hexToNumber } from 'viem'
-import { getDataSuffix as getCallDataSuffixOriginal, submitReferral } from '.'
-import { getDataSuffix as getCallDataSuffixViem } from '../test/viemReferenceVersion'
+import { getReferralTag as getReferralTagOriginal, submitReferral } from '.'
+import { getReferralTag as getReferralTagViem } from '../test/viemReferenceVersion'
 import { InvalidAddressError, Address } from './types'
-import { DIVVI_MAGIC_PREFIX, FORMAT_ID_BYTES } from './constants'
+import { DIVVI_MAGIC_PREFIX, REFERRAL_TAG_V2_FORMAT_BYTE } from './constants'
+
+const TEST_USER = '0x9999999999999999999999999999999999999999'
+const TEST_CONSUMER = '0x1234567890123456789012345678901234567890'
+const TEST_PROVIDERS = [
+  '0x0987654321098765432109876543210987654321',
+  '0xabCDeF0123456789AbcdEf0123456789aBCDEF01',
+  '0xfEdcBA9876543210FedCBa9876543210fEdCBa98',
+] as const
 
 describe.each([
-  ['Original', getCallDataSuffixOriginal],
-  ['Viem', getCallDataSuffixViem],
-])('getCallDataSuffix (%s)', (name, getCallDataSuffix) => {
+  ['Original', getReferralTagOriginal],
+  ['Viem', getReferralTagViem],
+])('getReferralTag (%s)', (name, getReferralTag) => {
   it(`[${name}] should throw if the consumer or provider is not a valid address`, () => {
     const badAddress: Address = '0x1234'
     const goodAddress: Address = '0x1234567890123456789012345678901234567890'
 
     expect(() =>
-      getCallDataSuffix({ consumer: goodAddress, providers: [badAddress] }),
+      getReferralTag({
+        user: goodAddress,
+        consumer: goodAddress,
+        providers: [badAddress],
+      }),
     ).toThrow(InvalidAddressError)
     expect(() =>
-      getCallDataSuffix({ consumer: badAddress, providers: [goodAddress] }),
+      getReferralTag({
+        user: goodAddress,
+        consumer: badAddress,
+        providers: [goodAddress],
+      }),
     ).toThrow(InvalidAddressError)
     expect(() =>
-      getCallDataSuffix({ consumer: badAddress, providers: [badAddress] }),
+      getReferralTag({
+        user: badAddress,
+        consumer: goodAddress,
+        providers: [goodAddress],
+      }),
     ).toThrow(InvalidAddressError)
     expect(() =>
-      getCallDataSuffix({ consumer: goodAddress, providers: [goodAddress] }),
+      getReferralTag({
+        user: goodAddress,
+        consumer: badAddress,
+        providers: [badAddress],
+      }),
+    ).toThrow(InvalidAddressError)
+    expect(() =>
+      getReferralTag({
+        user: badAddress,
+        consumer: badAddress,
+        providers: [badAddress],
+      }),
+    ).toThrow(InvalidAddressError)
+    expect(() =>
+      getReferralTag({
+        user: goodAddress,
+        consumer: goodAddress,
+        providers: [goodAddress],
+      }),
     ).not.toThrow()
   })
 
   it(`[${name}] should throw if there is no consumer`, () => {
-    const providers: Address[] = ['0x0987654321098765432109876543210987654321']
-
     expect(() =>
-      getCallDataSuffix({ consumer: '' as Address, providers }),
+      getReferralTag({
+        user: TEST_USER,
+        consumer: '' as Address,
+        providers: [TEST_PROVIDERS[0]],
+      }),
     ).toThrow(InvalidAddressError)
   })
 
-  it(`[${name}] should generate correct calldata suffix with no providers`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
-    const providers: Address[] = []
+  const testCases = [
+    {
+      name: 'no providers',
+      providers: [] as Address[],
+      expectedPayloadLength: '0080',
+    },
+    {
+      name: 'single provider',
+      providers: [TEST_PROVIDERS[0]],
+      expectedPayloadLength: '00a0',
+    },
+    {
+      name: 'multiple providers',
+      providers: TEST_PROVIDERS,
+      expectedPayloadLength: '00e0',
+    },
+  ]
 
-    const result = getCallDataSuffix({ consumer, providers })
+  it.each(testCases)(
+    `[${name}] should generate correct referral tag with $name`,
+    ({ providers, expectedPayloadLength }) => {
+      const result = getReferralTag({
+        user: TEST_USER,
+        consumer: TEST_CONSUMER,
+        providers,
+      })
 
-    // The result should be a hex string without 0x prefix
-    expect(result).toMatch(/^[0-9a-f]+$/)
+      // The result should be a hex string without 0x prefix
+      expect(result).toMatch(/^[0-9a-f]+$/)
 
-    // The first 8 characters should be the magic prefix (keccak256("divvi"))
-    const magicPrefix = result.slice(0, 8)
-    expect(magicPrefix).toBe(DIVVI_MAGIC_PREFIX)
+      // The first 8 characters should be the magic prefix (keccak256("divvi"))
+      const magicPrefix = result.slice(0, 8)
+      expect(magicPrefix).toBe(DIVVI_MAGIC_PREFIX)
 
-    // The format byte should be next
-    const formatByte = result.slice(8, 10)
-    expect(formatByte).toBe(FORMAT_ID_BYTES['default'])
+      // The format byte should be next
+      const formatByte = result.slice(8, 10)
+      expect(formatByte).toBe(REFERRAL_TAG_V2_FORMAT_BYTE)
 
-    // The last 8 characters should be the length of the data
-    const length = result.slice(-8)
-    expect(length).toBe('00000069')
+      // The next 4 characters should be the length of the payload
+      const payloadLength = result.slice(10, 14)
+      expect(payloadLength).toBe(expectedPayloadLength)
 
-    // The total length should be the length specified times 2 because every byte is 2 characters
-    const expectedTotalLength = hexToNumber('0x00000069') * 2
-    expect(result.length).toBe(expectedTotalLength)
+      // The payload length should be the length specified times 2 because every byte is 2 characters
+      const payload = result.slice(14)
+      expect(payload.length).toBe(hexToNumber(`0x${payloadLength}`) * 2)
 
-    // The data can be decoded correctly
-    const decodedData = decodeAbiParameters(
-      [{ type: 'address' }, { type: 'address[]' }],
-      `0x${result.slice(10, -8)}`, // Skip prefix and format byte
-    )
+      // The data can be decoded correctly
+      const decodedData = decodeAbiParameters(
+        [{ type: 'address' }, { type: 'address' }, { type: 'address[]' }],
+        `0x${payload}`,
+      )
 
-    expect(decodedData[0]).toBe(consumer)
-    expect(decodedData[1]).toEqual(providers)
-  })
-
-  it(`[${name}] should generate correct calldata suffix with single provider`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
-    const providers: Address[] = ['0x0987654321098765432109876543210987654321']
-
-    const result = getCallDataSuffix({ consumer, providers })
-
-    // The result should be a hex string without 0x prefix
-    expect(result).toMatch(/^[0-9a-f]+$/)
-
-    // The first 8 characters should be the magic prefix (keccak256("divvi"))
-    const magicPrefix = result.slice(0, 8)
-    expect(magicPrefix).toBe(DIVVI_MAGIC_PREFIX)
-
-    // The format byte should be next
-    const formatByte = result.slice(8, 10)
-    expect(formatByte).toBe(FORMAT_ID_BYTES['default'])
-
-    // The last 8 characters should be the length of the data
-    const length = result.slice(-8)
-    expect(length).toBe('00000089')
-
-    // The total length should be the length specified times 2 because every byte is 2 characters
-    const expectedTotalLength = hexToNumber('0x00000089') * 2
-    expect(result.length).toBe(expectedTotalLength)
-
-    // The data can be decoded correctly
-    const decodedData = decodeAbiParameters(
-      [{ type: 'address' }, { type: 'address[]' }],
-      `0x${result.slice(10, -8)}`, // Skip prefix and format byte
-    )
-
-    expect(decodedData[0]).toBe(consumer)
-    expect(decodedData[1]).toEqual(providers)
-  })
-
-  it(`[${name}] should generate correct calldata suffix with multiple providers`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
-    const providers: Address[] = [
-      '0x0987654321098765432109876543210987654321',
-      '0xabCDeF0123456789AbcdEf0123456789aBCDEF01',
-      '0xfEdcBA9876543210FedCBa9876543210fEdCBa98',
-    ]
-
-    const result = getCallDataSuffix({ consumer, providers })
-
-    // The result should be a hex string without 0x prefix
-    expect(result).toMatch(/^[0-9a-f]+$/)
-
-    // The first 8 characters should be the magic prefix (keccak256("divvi"))
-    const magicPrefix = result.slice(0, 8)
-    expect(magicPrefix).toBe(DIVVI_MAGIC_PREFIX)
-
-    // The format byte should be next
-    const formatByte = result.slice(8, 10)
-    expect(formatByte).toBe(FORMAT_ID_BYTES['default'])
-
-    // The last 8 characters should be the length of the data
-    const length = result.slice(-8)
-    expect(length).toBe('000000c9')
-
-    // The total length should be the length specified times 2 because every byte is 2 characters
-    const expectedTotalLength = hexToNumber('0x000000c9') * 2
-    expect(result.length).toBe(expectedTotalLength)
-
-    // The data can be decoded correctly
-    const decodedData = decodeAbiParameters(
-      [{ type: 'address' }, { type: 'address[]' }],
-      `0x${result.slice(10, -8)}`, // Skip prefix and format byte
-    )
-
-    expect(decodedData[0]).toBe(consumer)
-    expect(decodedData[1]).toEqual(providers)
-  })
+      expect(decodedData[0]).toBe(TEST_USER)
+      expect(decodedData[1]).toBe(TEST_CONSUMER)
+      expect(decodedData[2]).toEqual(providers)
+    },
+  )
 
   it(`[${name}] should handle empty providers array`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
     const providers: Address[] = []
 
-    const result = getCallDataSuffix({ consumer, providers })
+    const result = getReferralTag({
+      user: TEST_USER,
+      consumer: TEST_CONSUMER,
+      providers,
+    })
 
     expect(result).toMatch(/^[0-9a-f]+$/)
     expect(result.slice(0, 8)).toBe(DIVVI_MAGIC_PREFIX)
   })
 
   it(`[${name}] should generate consistent output for same inputs`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
-    const providers: Address[] = ['0x0987654321098765432109876543210987654321']
-
-    const result1 = getCallDataSuffix({ consumer, providers })
-    const result2 = getCallDataSuffix({ consumer, providers })
-
-    expect(result1).toBe(result2)
-  })
-
-  it(`[${name}] should use default format ID when not specified`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
-    const providers: Address[] = ['0x0987654321098765432109876543210987654321']
-
-    const result = getCallDataSuffix({ consumer, providers })
-
-    // The format byte should be the default one
-    const formatByte = result.slice(8, 10)
-    expect(formatByte).toBe(FORMAT_ID_BYTES['default'])
-  })
-
-  it(`[${name}] should use specified format ID when provided`, () => {
-    const consumer: Address = '0x1234567890123456789012345678901234567890'
-    const providers: Address[] = ['0x0987654321098765432109876543210987654321']
-
-    const result = getCallDataSuffix({
-      consumer,
-      providers,
+    const result1 = getReferralTag({
+      user: TEST_USER,
+      consumer: TEST_CONSUMER,
+      providers: [TEST_PROVIDERS[0]],
+    })
+    const result2 = getReferralTag({
+      user: TEST_USER,
+      consumer: TEST_CONSUMER,
+      providers: [TEST_PROVIDERS[0]],
     })
 
-    // The format byte should match the specified format
-    const formatByte = result.slice(8, 10)
-    expect(formatByte).toBe(FORMAT_ID_BYTES['default'])
+    expect(result1).toBe(result2)
   })
 })
 
@@ -193,33 +165,33 @@ describe('Implementation comparison', () => {
   const testCases: Array<{
     name: string
     input: {
+      user: Address
       consumer: Address
-      providers: Address[]
+      providers: readonly Address[]
     }
   }> = [
     {
       name: 'empty providers array',
       input: {
-        consumer: '0x1234567890123456789012345678901234567890',
+        user: TEST_USER,
+        consumer: TEST_CONSUMER,
         providers: [],
       },
     },
     {
       name: 'single provider',
       input: {
-        consumer: '0x1234567890123456789012345678901234567890',
-        providers: ['0x0987654321098765432109876543210987654321'],
+        user: TEST_USER,
+        consumer: TEST_CONSUMER,
+        providers: [TEST_PROVIDERS[0]],
       },
     },
     {
       name: 'multiple providers',
       input: {
-        consumer: '0x1234567890123456789012345678901234567890',
-        providers: [
-          '0x0987654321098765432109876543210987654321',
-          '0xabCDeF0123456789AbcdEf0123456789aBCDEF01',
-          '0xfEdcBA9876543210FedCBa9876543210fEdCBa98',
-        ],
+        user: TEST_USER,
+        consumer: TEST_CONSUMER,
+        providers: TEST_PROVIDERS,
       },
     },
   ]
@@ -227,8 +199,8 @@ describe('Implementation comparison', () => {
   it.each(testCases)(
     'should produce identical results for both implementations: $name',
     ({ input }) => {
-      const resultOriginal = getCallDataSuffixOriginal(input)
-      const resultViem = getCallDataSuffixViem(input)
+      const resultOriginal = getReferralTagOriginal(input)
+      const resultViem = getReferralTagViem(input)
 
       expect(resultOriginal).toBe(resultViem)
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { DIVVI_MAGIC_PREFIX, REFERRAL_TAG_V2_FORMAT_BYTE } from './constants'
+import { DIVVI_MAGIC_PREFIX, REFERRAL_TAG_FORMAT_1_BYTE } from './constants'
 import { InvalidAddressError, Address } from './types'
 
 // Helper function to validate Ethereum addresses
@@ -84,7 +84,7 @@ export function getReferralTag({
   // Combine all parts
   return (
     DIVVI_MAGIC_PREFIX +
-    REFERRAL_TAG_V2_FORMAT_BYTE +
+    REFERRAL_TAG_FORMAT_1_BYTE +
     payloadLengthHex +
     encodedBytes
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,6 @@
  */
 export type Address = `0x${string}`
 
-/**
- * Format identifier for the data suffix encoding.
- */
-export type FormatID = 'default'
-
 export class InvalidAddressError extends Error {
   constructor({ address }: { address: string }) {
     super(`Invalid Ethereum address: ${address}`)

--- a/test/viemReferenceVersion.ts
+++ b/test/viemReferenceVersion.ts
@@ -7,21 +7,27 @@ import {
   isAddress,
 } from 'viem'
 import { InvalidAddressError, Address } from '../src/types'
-import { FORMAT_ID_BYTES } from '../src/constants'
+import { REFERRAL_TAG_V2_FORMAT_BYTE } from '../src/constants'
 
 /**
  * @deprecated This function is deprecated and should only be used to validate and compare
- * its functionality to getDataSuffix in index.ts. Do not use this function in production code.
+ * its functionality to getReferralTag in index.ts. Do not use this function in production code.
  */
-export function getDataSuffix({
+export function getReferralTag({
+  user,
   consumer,
   providers = [],
 }: {
+  user: Address
   consumer: Address
-  providers?: Address[]
+  providers?: readonly Address[]
 }): string {
   // Compute the first 4 bytes of the function selector for "divvi"
   const magicPrefixBytes = keccak256(toBytes('divvi')).slice(2, 10) // remove "0x", take first 8 hex chars (4 bytes)
+
+  if (!isAddress(user)) {
+    throw new InvalidAddressError({ address: user })
+  }
 
   if (!isAddress(consumer)) {
     throw new InvalidAddressError({ address: consumer })
@@ -35,20 +41,20 @@ export function getDataSuffix({
 
   // Encode parameters: (address, address[])
   const encodedData = encodeAbiParameters(
-    [{ type: 'address' }, { type: 'address[]' }],
-    [consumer, providers],
+    [{ type: 'address' }, { type: 'address' }, { type: 'address[]' }],
+    [user, consumer, providers],
   )
-
-  // Get the format byte
-  const formatByte = FORMAT_ID_BYTES['default']
 
   // Calculate total length
   const encodedBytes = hexToBytes(encodedData)
-  const totalLength = 4 + 1 + encodedBytes.length + 4 // 4 for prefix, 1 for format byte, rest for data and length
-  const lengthHex = totalLength.toString(16).padStart(8, '0') // uint32 as 8 hex chars
+  const payloadLength = encodedBytes.length
+  const payloadLengthHex = payloadLength.toString(16).padStart(4, '0') // uint16 as 4 hex chars
 
   // Construct appended data and final calldata
   const appendedData =
-    magicPrefixBytes + formatByte + encodedData.slice(2) + lengthHex
+    magicPrefixBytes +
+    REFERRAL_TAG_V2_FORMAT_BYTE +
+    payloadLengthHex +
+    encodedData.slice(2)
   return appendedData
 }

--- a/test/viemReferenceVersion.ts
+++ b/test/viemReferenceVersion.ts
@@ -7,7 +7,7 @@ import {
   isAddress,
 } from 'viem'
 import { InvalidAddressError, Address } from '../src/types'
-import { REFERRAL_TAG_V2_FORMAT_BYTE } from '../src/constants'
+import { REFERRAL_TAG_FORMAT_1_BYTE } from '../src/constants'
 
 /**
  * @deprecated This function is deprecated and should only be used to validate and compare
@@ -53,7 +53,7 @@ export function getReferralTag({
   // Construct appended data and final calldata
   const appendedData =
     magicPrefixBytes +
-    REFERRAL_TAG_V2_FORMAT_BYTE +
+    REFERRAL_TAG_FORMAT_1_BYTE +
     payloadLengthHex +
     encodedData.slice(2)
   return appendedData


### PR DESCRIPTION
Replace getDataSuffix function with getReferralTag and add a required user parameter to improve API clarity and enhance referral attribution workflows. The user parameter makes the attribution process more explicit and improves the developer experience.

Part of ENG-426

BREAKING CHANGE: `getDataSuffix` has been replaced with `getReferralTag` and now requires a `user` parameter.

Migration steps:

1. Replace `getDataSuffix` imports with `getReferralTag`
2. Add the required user parameter to all `getReferralTag` calls

See the migration guide in README.md for detailed instructions: https://github.com/divvi-xyz/divvi-referral-sdk#migration-from-v1-to-v2